### PR TITLE
Remove "unsafe" code

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,13 +302,6 @@ export function sign(h, d, e) {
   if (!isExtraData(e)) {
     throw new Error('Expected Extra Data (32 bytes)');
   }
-  if (
-    Buffer.from(h).toString('hex') ===
-    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-  )
-    throw new Error(
-      'Noble Ecc returns different values than Bitcoin Core for h = 0xffff.... This behavior is unsafe, so it has been disabled for safety reasons.'
-    );
   return necc.signSync(h, d, { der: false, extraEntropy: e });
 }
 


### PR DESCRIPTION
It is not noble who is wrong, it is your version of libsecp256k1, which is old. Upgrade libsecp256k1, and you'll see the proper result, which matches noble.