### PR TITLE
Feature enhancement: Incorporate PR #8 methods and version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/secp256k1",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/secp256k1",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitcoinerlab/secp256k1",
   "homepage": "https://bitcoinerlab.com/secp256k1",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A library for performing elliptic curve operations on the secp256k1 curve. It is designed to integrate into the BitcoinJS & BitcoinerLAB ecosystems and uses the audited noble-secp256k1 library. It is compatible with environments that do not support WASM, such as React Native.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
This PR builds upon the recently merged PR #8 by adding support for the `recover` and `signRecoverable` methods, aligning our API closer to `tiny-secp256k1`. In addition to integrating these methods, this PR also bumps the minor version to `1.1.0`, reflecting the new features introduced.

Changes:
- Updated `package.json` and `package-lock.json` to version `1.1.0`.