### PR TITLE
Migrate from @noble/secp256k1 to @noble/curves for enhanced security

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This implementation follows the tiny-secp256k1 API. Please refer to [tiny-secp25
 
 - **`xOnlyPointAddTweakCheck`**: This method is not yet implemented. It is not used in `ecpair` or `bip32`.
 
-- **`signSchnorr`**: Starting from version 1.2.0, this function no longer initializes the auxiliary random data parameter (`e`) to a zero-filled array by default. Instead, it requires the caller to explicitly provide randomness if desired. If omitted, the underlying implementation uses cryptographically secure randomness (through `crypto.getRandomValues`). For more details on this change, see the discussion [here](https://github.com/bitcoinerlab/secp256k1/pull/10#discussion_r1876541974) and the conclusions [here](https://github.com/bitcoinerlab/secp256k1/pull/10#issuecomment-2537916286).
+- **`signSchnorr`**: Starting from version 1.2.0, this function deviates from the exact behavior mapping with [`bitcoinjs/tiny-secp256k1`](https://github.com/bitcoinjs/tiny-secp256k1) and no longer initializes the auxiliary random data parameter (`e`) to a zero-filled array by default. Instead, it requires the caller to explicitly provide randomness if desired. If omitted, the underlying implementation uses cryptographically secure randomness (through `crypto.getRandomValues`). For more details on this change, see the discussion [here](https://github.com/bitcoinerlab/secp256k1/pull/10#discussion_r1876541974) and the conclusions [here](https://github.com/bitcoinerlab/secp256k1/pull/10#issuecomment-2537916286).
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Test this: https://github.com/spsina/bip47
 
 # Secp256k1
 
-@bitcoinerlab/secp256k1 is a Javascript library for performing elliptic curve operations on the secp256k1 curve. It is designed to integrate into the [BitcoinJS](https://github.com/bitcoinjs) and [BitcoinerLAB](https://bitcoinerlab.com) ecosystems and uses the audited [noble-secp256k1 library](https://github.com/paulmillr/noble-secp256k1), created by [Paul Miller](https://paulmillr.com/noble/).
+@bitcoinerlab/secp256k1 is a Javascript library for performing elliptic curve operations on the secp256k1 curve. It is designed to integrate into the [BitcoinJS](https://github.com/bitcoinjs) and [BitcoinerLAB](https://bitcoinerlab.com) ecosystems and uses the audited [noble-curves library](https://github.com/paulmillr/noble-curves), created by [Paul Miller](https://paulmillr.com/noble/).
 
  This library is compatible with environments that do not support WebAssembly, such as React Native.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ npm install @bitcoinerlab/secp256k1
 
 This implementation follows the tiny-secp256k1 API. Please refer to [tiny-secp256k1](https://github.com/bitcoinjs/tiny-secp256k1#documentation) for documentation on the methods.
 
-This method is not yet implemented: `xOnlyPointAddTweakCheck`. It is not used in ecpair or bip32, though.
+- **`xOnlyPointAddTweakCheck`**: This method is not yet implemented. It is not used in `ecpair` or `bip32`.
+
+- **`signSchnorr`**: Starting from version 1.2.0, this function no longer initializes the auxiliary random data parameter (`e`) to a zero-filled array by default. Instead, it requires the caller to explicitly provide randomness if desired. If omitted, the underlying implementation uses cryptographically secure randomness (through `crypto.getRandomValues`). For more details on this change, see the discussion [here](https://github.com/bitcoinerlab/secp256k1/pull/10#discussion_r1876541974) and the conclusions [here](https://github.com/bitcoinerlab/secp256k1/pull/10#issuecomment-2537916286).
 
 ### Examples
 

--- a/index.js
+++ b/index.js
@@ -14,18 +14,18 @@
  * tiny-secp256k1 (https://github.com/bitcoinjs/tiny-secp256k1/tests).
  */
 
-import * as necc from '@noble/secp256k1';
-import { hmac } from '@noble/hashes/hmac';
-import { sha256 } from '@noble/hashes/sha256';
+import * as necc from "@noble/secp256k1";
+import { hmac } from "@noble/hashes/hmac";
+import { sha256 } from "@noble/hashes/sha256";
 
-const THROW_BAD_PRIVATE = 'Expected Private'
-const THROW_BAD_POINT = 'Expected Point'
-const THROW_BAD_TWEAK = 'Expected Tweak'
-const THROW_BAD_HASH = 'Expected Hash'
-const THROW_BAD_SIGNATURE = 'Expected Signature'
-const THROW_BAD_EXTRA_DATA = 'Expected Extra Data (32 bytes)'
-const THROW_BAD_SCALAR = 'Expected Scalar'
-const THROW_BAD_RECOVERY_ID = 'Bad Recovery Id'
+const THROW_BAD_PRIVATE = "Expected Private";
+const THROW_BAD_POINT = "Expected Point";
+const THROW_BAD_TWEAK = "Expected Tweak";
+const THROW_BAD_HASH = "Expected Hash";
+const THROW_BAD_SIGNATURE = "Expected Signature";
+const THROW_BAD_EXTRA_DATA = "Expected Extra Data (32 bytes)";
+const THROW_BAD_SCALAR = "Expected Scalar";
+const THROW_BAD_RECOVERY_ID = "Bad Recovery Id";
 
 necc.utils.hmacSha256Sync = (key, ...msgs) =>
   hmac(sha256, key, necc.utils.concatBytes(...msgs));
@@ -37,7 +37,7 @@ const HASH_SIZE = 32;
 const TWEAK_SIZE = 32;
 const BN32_N = new Uint8Array([
   255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-  254, 186, 174, 220, 230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65
+  254, 186, 174, 220, 230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65,
 ]);
 const EXTRA_DATA_SIZE = 32;
 
@@ -63,7 +63,6 @@ function cmpBN32(data1, data2) {
 function isZero(x) {
   return cmpBN32(x, BN32_ZERO) === 0;
 }
-
 
 function isTweak(tweak) {
   // Check that the tweak is a Uint8Array of the correct length
@@ -95,7 +94,9 @@ function isSigrLessThanPMinusN(signature) {
 }
 
 function isSignatureNonzeroRS(signature) {
-  return !(isZero(signature.subarray(0, 32)) || isZero(signature.subarray(32, 64)))
+  return !(
+    isZero(signature.subarray(0, 32)) || isZero(signature.subarray(32, 64))
+  );
 }
 
 function isHash(h) {
@@ -109,8 +110,8 @@ function isExtraData(e) {
 }
 
 function hexToNumber(hex) {
-  if (typeof hex !== 'string') {
-    throw new TypeError('hexToNumber: expected string, got ' + typeof hex);
+  if (typeof hex !== "string") {
+    throw new TypeError("hexToNumber: expected string, got " + typeof hex);
   }
   return BigInt(`0x${hex}`);
 }
@@ -121,26 +122,26 @@ function bytesToNumber(bytes) {
 
 function normalizeScalar(scalar) {
   let num;
-  if (typeof scalar === 'bigint') {
+  if (typeof scalar === "bigint") {
     num = scalar;
   } else if (
-    typeof scalar === 'number' &&
+    typeof scalar === "number" &&
     Number.isSafeInteger(scalar) &&
     scalar >= 0
   ) {
     num = BigInt(scalar);
-  } else if (typeof scalar === 'string') {
+  } else if (typeof scalar === "string") {
     if (scalar.length !== 64)
-      throw new Error('Expected 32 bytes of private scalar');
+      throw new Error("Expected 32 bytes of private scalar");
     num = hexToNumber(scalar);
   } else if (scalar instanceof Uint8Array) {
     if (scalar.length !== 32)
-      throw new Error('Expected 32 bytes of private scalar');
+      throw new Error("Expected 32 bytes of private scalar");
     num = bytesToNumber(scalar);
   } else {
-    throw new TypeError('Expected valid private scalar');
+    throw new TypeError("Expected valid private scalar");
   }
-  if (num < 0) throw new Error('Expected private scalar >= 0');
+  if (num < 0) throw new Error("Expected private scalar >= 0");
   return num;
 }
 
@@ -160,7 +161,7 @@ const _privateSub = (privateKey, tweak) => {
   else return null;
 };
 
-const _privateNegate = privateKey => {
+const _privateNegate = (privateKey) => {
   const p = normalizePrivateKey(privateKey);
   const not = necc.utils._bigintTo32Bytes(necc.CURVE.n - p);
   if (necc.utils.isValidPrivateKey(not)) return not;
@@ -171,13 +172,13 @@ const _pointAddScalar = (p, tweak, isCompressed) => {
   const P = necc.Point.fromHex(p);
   const t = normalizeScalar(tweak);
   const Q = necc.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1));
-  if (!Q) throw new Error('Tweaked point at infinity');
+  if (!Q) throw new Error("Tweaked point at infinity");
   return Q.toRawBytes(isCompressed);
 };
 
 const _pointMultiply = (p, tweak, isCompressed) => {
   const P = necc.Point.fromHex(p);
-  const h = typeof tweak === 'string' ? tweak : necc.utils.bytesToHex(tweak);
+  const h = typeof tweak === "string" ? tweak : necc.utils.bytesToHex(tweak);
   const t = BigInt(`0x${h}`);
   return P.multiply(t).toRawBytes(isCompressed);
 };
@@ -249,7 +250,7 @@ export function pointFromScalar(sk, compressed) {
     throw new Error(THROW_BAD_PRIVATE);
   }
   return throwToNull(() =>
-    necc.getPublicKey(sk, assumeCompression(compressed))
+    necc.getPublicKey(sk, assumeCompression(compressed)),
   );
 }
 
@@ -275,7 +276,7 @@ export function pointMultiply(a, tweak, compressed) {
     throw new Error(THROW_BAD_TWEAK);
   }
   return throwToNull(() =>
-    _pointMultiply(a, tweak, assumeCompression(compressed, a))
+    _pointMultiply(a, tweak, assumeCompression(compressed, a)),
   );
 }
 
@@ -302,7 +303,7 @@ export function pointAddScalar(p, tweak, compressed) {
     throw new Error(THROW_BAD_TWEAK);
   }
   return throwToNull(() =>
-    _pointAddScalar(p, tweak, assumeCompression(compressed, p))
+    _pointAddScalar(p, tweak, assumeCompression(compressed, p)),
   );
 }
 
@@ -356,8 +357,12 @@ export function signRecoverable(h, d, e) {
   if (!isExtraData(e)) {
     throw new Error(THROW_BAD_EXTRA_DATA);
   }
-  const [signature, recoveryId] = necc.signSync(h, d, { der: false, extraEntropy: e, recovered: true });
-  return { signature, recoveryId }
+  const [signature, recoveryId] = necc.signSync(h, d, {
+    der: false,
+    extraEntropy: e,
+    recovered: true,
+  });
+  return { signature, recoveryId };
 }
 
 export function signSchnorr(h, d, e = Buffer.alloc(32, 0x00)) {
@@ -373,24 +378,30 @@ export function signSchnorr(h, d, e = Buffer.alloc(32, 0x00)) {
   return necc.schnorr.signSync(h, d, e);
 }
 
-export function recover(h, signature, recoveryId, compressed){
-  if (!isHash(h)){
+export function recover(h, signature, recoveryId, compressed) {
+  if (!isHash(h)) {
     throw new Error(THROW_BAD_HASH);
   }
 
-  if(!isSignature(signature) || !isSignatureNonzeroRS(signature)){
-    throw new Error(THROW_BAD_SIGNATURE)
+  if (!isSignature(signature) || !isSignatureNonzeroRS(signature)) {
+    throw new Error(THROW_BAD_SIGNATURE);
   }
 
   if (recoveryId & 2) {
-    if (!isSigrLessThanPMinusN(signature)) throw new Error(THROW_BAD_RECOVERY_ID)
-  }
-  
-  if (!isXOnlyPoint(signature.subarray(0, 32))){
-    throw new Error(THROW_BAD_SIGNATURE)
+    if (!isSigrLessThanPMinusN(signature))
+      throw new Error(THROW_BAD_RECOVERY_ID);
   }
 
-  return necc.recoverPublicKey(h, signature, recoveryId, assumeCompression(compressed));
+  if (!isXOnlyPoint(signature.subarray(0, 32))) {
+    throw new Error(THROW_BAD_SIGNATURE);
+  }
+
+  return necc.recoverPublicKey(
+    h,
+    signature,
+    recoveryId,
+    assumeCompression(compressed),
+  );
 }
 
 export function verify(h, Q, signature, strict) {

--- a/index.js
+++ b/index.js
@@ -41,11 +41,6 @@ const BN32_P_MINUS_N = new Uint8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 69, 81, 35, 25, 80, 183, 95,
   196, 64, 45, 161, 114, 47, 201, 186, 238,
 ]);
-
-const secp256k1P = BigInt(
-  "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-);
-const _0n = BigInt(0);
 const _1n = BigInt(1);
 
 function isUint8Array(value) {
@@ -137,9 +132,6 @@ function normalizeScalar(scalar) {
 function normalizePrivateKey(privateKey) {
   return secp256k1.utils.normPrivateKeyToScalar(privateKey);
 }
-
-const CURVE = secp256k1.CURVE;
-const { Fp } = CURVE;
 
 function _privateAdd(privateKey, tweak) {
   const p = normalizePrivateKey(privateKey);

--- a/index.js
+++ b/index.js
@@ -359,7 +359,7 @@ export function signRecoverable(h, d, e) {
   };
 }
 
-export function signSchnorr(h, d, e = new Uint8Array(32)) {
+export function signSchnorr(h, d, e) {
   if (!isPrivate(d)) {
     throw new Error(THROW_BAD_PRIVATE);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@bitcoinerlab/secp256k1",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/secp256k1",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.5",
-        "@noble/secp256k1": "^1.7.1"
+        "@noble/curves": "^1.7.0"
       },
       "devDependencies": {
         "@babel/node": "^7.20.7",
@@ -470,27 +469,30 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+    "node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.0",
@@ -3020,15 +3022,20 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    "@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "requires": {
+        "@noble/hashes": "1.6.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+          "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ=="
+        }
+      }
     },
     "@types/estree": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitcoinerlab/secp256k1",
   "homepage": "https://bitcoinerlab.com/secp256k1",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A library for performing elliptic curve operations on the secp256k1 curve. It is designed to integrate into the BitcoinJS & BitcoinerLAB ecosystems and uses the audited noble-secp256k1 library. It is compatible with environments that do not support WASM, such as React Native.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -41,7 +41,6 @@
     "tape": "^5.6.1"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.5",
-    "@noble/secp256k1": "^1.7.1"
+    "@noble/curves": "^1.7.0"
   }
 }


### PR DESCRIPTION
### Overview
This PR replaces the dependency `@noble/secp256k1` with `@noble/curves` for enhanced security and maintainability, following the advice of @paulmillr (https://github.com/bitcoinerlab/secp256k1/issues/6#issuecomment-2525124149). The migration ensures compatibility with the existing API.

### Changes
- Replaced all references to `@noble/secp256k1` with the appropriate modules from `@noble/curves`.

### Impact
- ~~**No breaking changes**: The public API remains unchanged, ensuring a seamless upgrade for users.~~
- **Updated behavior**: The `signSchnorr` function no longer defaults to a zero-filled `auxRand` for compatibility reasons. It now requires an explicit value or uses a secure random value internally.
- **Better maintainability**: By following the latest recommendations from the library's author, the codebase stays in sync with upstream improvements.

### Version
- Bumped version from `1.1.1` to `1.2.0` to indicate the significant internal change while keeping the same external functionality.

### Testing
- All existing tests pass with the updated dependency.